### PR TITLE
Changed map layer from MQ to OpenStreetMap Mapnik

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,13 +6,12 @@
   "maxAge": 14,
   "mapLayers": [
     {
-      "name": "MapQuest",
-      "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
+      "name": "OpenStreetMap",
+      "url": "https:///tiles.aachen.freifunk.net/{z}/{x}/{y}.png",
       "config": {
-        "subdomains": "1234",
         "type": "osm",
-        "attribution": "Tiles &copy; <a href=\"https://www.mapquest.com/\" target=\"_blank\">MapQuest</a>, Data CC-BY-SA OpenStreetMap",
-        "maxZoom": 18
+        "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap-Mitwirkende</a>",
+        "maxZoom": 19
       }
     },
     {

--- a/config.json
+++ b/config.json
@@ -7,8 +7,9 @@
   "mapLayers": [
     {
       "name": "OpenStreetMap",
-      "url": "https:///tiles.aachen.freifunk.net/{z}/{x}/{y}.png",
+      "url": "https:///tiles{s}.aachen.freifunk.net/{z}/{x}/{y}.png",
       "config": {
+        "subdomains": "1234",
         "type": "osm",
         "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap-Mitwirkende</a>",
         "maxZoom": 19


### PR DESCRIPTION
We now have a caching proxy on https://tiles.aachen.freifunk.net which serves standard OSM tiles.